### PR TITLE
Add new Chatbot data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Open <http://localhost:3000/> in your browser.
 - [x] Async and Await
 - [x] Joining Futures
 - [x] Spawning Tasks
+- [x] Message Passing

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -20,27 +20,30 @@ pub async fn gen_random_number() -> usize {
 
 /// A chatbot that responds to inputs.
 pub struct Chatbot {
-    emoji: String,
+    emojis: Vec<String>,
+    emoji_counter: usize,
 }
 
 impl Chatbot {
     /// Creates a new chatbot that uses the provided emoji in its responses.
-    pub fn new(emoji: String) -> Self {
-        Chatbot { emoji }
+    pub fn new(emojis: Vec<String>) -> Self {
+        Chatbot {
+            emojis,
+            emoji_counter: 0,
+        }
     }
 
     /// Generates a list of possible responses given the current chat.
     ///
     /// Warning: may take a few seconds!
-    pub async fn query_chat(&self, messages: &[String]) -> Vec<String> {
+    pub async fn query_chat(&mut self, messages: &[String]) -> Vec<String> {
         std::thread::sleep(Duration::from_secs(2));
         let most_recent = messages.last().unwrap();
+        let emoji = &self.emojis[self.emoji_counter];
+        self.emoji_counter = (self.emoji_counter + 1) % self.emojis.len();
         vec![
-            format!(
-                "\"{most_recent}\"? And how does that make you feel? {}",
-                self.emoji
-            ),
-            format!("\"{most_recent}\"! Interesting! Go on... {}", self.emoji),
+            format!("\"{most_recent}\"? And how does that make you feel? {emoji}",),
+            format!("\"{most_recent}\"! Interesting! Go on... {emoji}"),
         ]
     }
 }

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -18,14 +18,29 @@ pub async fn gen_random_number() -> usize {
     RNG.with(|rng| rng.borrow_mut().gen())
 }
 
-/// Generates a list of possible responses given the current chat.
-///
-/// Warning: may take a few seconds!
-pub async fn query_chat(messages: &[String]) -> Vec<String> {
-    std::thread::sleep(Duration::from_secs(2));
-    let most_recent = messages.last().unwrap();
-    vec![
-        format!("\"{most_recent}\"? And how does that make you feel?"),
-        format!("\"{most_recent}\"! Interesting! Go on..."),
-    ]
+/// A chatbot that responds to inputs.
+pub struct Chatbot {
+    emoji: String,
+}
+
+impl Chatbot {
+    /// Creates a new chatbot that uses the provided emoji in its responses.
+    pub fn new(emoji: String) -> Self {
+        Chatbot { emoji }
+    }
+
+    /// Generates a list of possible responses given the current chat.
+    ///
+    /// Warning: may take a few seconds!
+    pub async fn query_chat(&self, messages: &[String]) -> Vec<String> {
+        std::thread::sleep(Duration::from_secs(2));
+        let most_recent = messages.last().unwrap();
+        vec![
+            format!(
+                "\"{most_recent}\"? And how does that make you feel? {}",
+                self.emoji
+            ),
+            format!("\"{most_recent}\"! Interesting! Go on... {}", self.emoji),
+        ]
+    }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,7 +1,8 @@
 use miniserve::{http, Content, Request, Response};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::join;
+use tokio::sync::{mpsc, oneshot};
 
 async fn index(_req: Request) -> Response {
     let content = include_str!("../index.html").to_string();
@@ -18,6 +19,26 @@ struct ChatResponse {
     messages: Vec<String>,
 }
 
+async fn query_chat(messages: &Arc<Vec<String>>) -> Vec<String> {
+    type Payload = (Arc<Vec<String>>, oneshot::Sender<Vec<String>>);
+
+    static SENDER: LazyLock<mpsc::Sender<Payload>> = LazyLock::new(|| {
+        let (tx, mut rx) = mpsc::channel::<Payload>(1024);
+        tokio::spawn(async move {
+            let mut chatbot = chatbot::Chatbot::new(vec![":-)".to_string(), "^^".to_string()]);
+            while let Some((messages, responder)) = rx.recv().await {
+                let response = chatbot.query_chat(&messages).await;
+                responder.send(response).unwrap();
+            }
+        });
+        tx
+    });
+
+    let (tx, rx) = oneshot::channel();
+    SENDER.send((messages.clone(), tx)).await.unwrap();
+    rx.await.unwrap()
+}
+
 async fn chat(req: Request) -> Response {
     let Request::Post(body) = req else {
         return Err(http::StatusCode::METHOD_NOT_ALLOWED);
@@ -29,13 +50,8 @@ async fn chat(req: Request) -> Response {
 
     let messages = Arc::new(chat_req.messages);
 
-    let messages_clone = messages.clone();
-    let (generated, idx) = join!(
-        tokio::spawn(async move { chatbot::query_chat(&messages_clone).await }),
-        chatbot::gen_random_number()
-    );
+    let (generated, idx) = join!(query_chat(&messages), chatbot::gen_random_number());
 
-    let generated = generated.unwrap();
     let new_message = generated[idx % generated.len()].clone();
     let mut messages = Arc::into_inner(messages).unwrap();
     messages.push(new_message);


### PR DESCRIPTION
Refactors `chatbot::query_chat` into a method on the `Chatbot` data structure. This causes the build to break for the `server` crate. The main changes are:
* `Chatbot::new` takes as input a vector of emojis, which the chatbot will include to improve the attitude of users.
* `Chatbot::query_chat` is stateful because it rotates through emojis to keep the chat fresh.

Resolves #9. (Don't merge until you've added your solution!)
