### PR TITLE
Add Logger data structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+Cargo.lock
 log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-Cargo.lock
+log.txt

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Open <http://localhost:3000/> in your browser.
 - [x] Waiting on Many Futures
 - [x] Selecting Between Futures
 - [x] Pinning Futures
+- [x] Async Abstractions

--- a/crates/chatbot/Cargo.toml
+++ b/crates/chatbot/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["time", "fs"] }

--- a/crates/server/src/stateful.rs
+++ b/crates/server/src/stateful.rs
@@ -1,0 +1,71 @@
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::pin;
+use std::time::Duration;
+use tokio::select;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+pub trait StatefulFunction: Send + 'static {
+    type Input: Send;
+    type Output: Send + Debug;
+
+    fn call(&mut self, input: Self::Input) -> impl Future<Output = Self::Output> + Send;
+}
+
+type Payload<F> = (
+    <F as StatefulFunction>::Input,
+    oneshot::Sender<Option<<F as StatefulFunction>::Output>>,
+);
+
+pub struct StatefulThread<F: StatefulFunction> {
+    _handle: JoinHandle<()>,
+    input_tx: mpsc::Sender<Payload<F>>,
+    cancel_tx: mpsc::Sender<()>,
+}
+
+impl<F: StatefulFunction> StatefulThread<F> {
+    pub fn new(mut func: F) -> Self {
+        let (input_tx, mut input_rx) = mpsc::channel::<Payload<F>>(1024);
+        let (cancel_tx, mut cancel_rx) = mpsc::channel::<()>(1);
+        let _handle = tokio::spawn(async move {
+            while let Some((input, responder)) = input_rx.recv().await {
+                let mut output_fut = pin!(func.call(input));
+                let mut cancel_fut = pin!(cancel_rx.recv());
+                let start = Instant::now();
+                loop {
+                    let log_fut = tokio::time::sleep(Duration::from_secs(1));
+                    select! {
+                        response = &mut output_fut => {
+                            responder.send(Some(response)).unwrap();
+                            break;
+                        }
+                        _ = &mut cancel_fut => {
+                            responder.send(None).unwrap();
+                            break;
+                        }
+                        _ = log_fut => {
+                            println!("Waiting for {} seconds", start.elapsed().as_secs());
+                        }
+                    }
+                }
+            }
+        });
+        Self {
+            _handle,
+            input_tx,
+            cancel_tx,
+        }
+    }
+
+    pub async fn call(&self, input: F::Input) -> Option<F::Output> {
+        let (tx, rx) = oneshot::channel();
+        self.input_tx.send((input, tx)).await.unwrap();
+        rx.await.unwrap()
+    }
+
+    pub async fn cancel(&self) {
+        self.cancel_tx.send(()).await.unwrap();
+    }
+}


### PR DESCRIPTION
Defines a `chatbot::Logger` type that has two methods: `Logger::append` for adding a message, and `Logger::save` for intermittently writing to disk. You can construct a logger via `Logger::default()`.

Resolves #17. (Don't merge until you've added your solution!)
